### PR TITLE
Lagre AsicE-arkiv til fil

### DIFF
--- a/SikkerDigitalPost.Klient/AsicE/AsicEArkiv.cs
+++ b/SikkerDigitalPost.Klient/AsicE/AsicEArkiv.cs
@@ -20,6 +20,7 @@ using System.Security.Cryptography.X509Certificates;
 using SikkerDigitalPost.Domene.Entiteter.Interface;
 using SikkerDigitalPost.Domene.Entiteter.Post;
 using System.Diagnostics;
+using SikkerDigitalPost.Klient.Utilities;
 
 namespace SikkerDigitalPost.Klient.AsicE
 {
@@ -111,6 +112,11 @@ namespace SikkerDigitalPost.Klient.AsicE
 
             byte[] ziparray = stream.ToArray();
             return stream.ToArray();
+        }
+
+        public void LagreTilDisk(params string[] filsti)
+        {
+            FileUtility.WriteToBasePath(UkrypterteBytes, filsti);
         }
 
         private void LeggFilTilArkiv(ZipArchive archive, string filename, byte[] data)

--- a/SikkerDigitalPost.Klient/KlientKonfigurasjon.cs
+++ b/SikkerDigitalPost.Klient/KlientKonfigurasjon.cs
@@ -22,7 +22,7 @@ namespace SikkerDigitalPost.Klient
 {
     /// <summary>
     /// Inneholder konfigurasjon for sending av digital post.
-    /// </summary>
+    /// </summary> 
     public class Klientkonfigurasjon
     {
         /// <summary>
@@ -101,7 +101,7 @@ namespace SikkerDigitalPost.Klient
             TimeoutIMillisekunder = SetFromAppConfig<int>("SDP:TimeoutIMillisekunder", (int)TimeSpan.FromSeconds(30).TotalMilliseconds);
             Logger = Logging.TraceLogger();
             DebugLoggTilFil = SetFromAppConfig<bool>("SDP:DebugLoggTilFil", false);
-            StandardLoggSti = SetFromAppConfig<string>("SDP:LoggSti", Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Digipost", "Logg"));
+            StandardLoggSti = SetFromAppConfig<string>("SDP:LoggSti", Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Digipost"));
         }
 
         private T SetFromAppConfig<T>(string key, T @default)


### PR DESCRIPTION
Som ønsket av Arne Berner for en stund tilbake, har jeg lagt til mulighet til å lagre ASicE-arkivet til disk. Dette blir lagret i mappe "dokumentpakke" til rot av loggsti. 
