### PR TITLE
Logg Xml til Fil

### DIFF
--- a/Difi.SikkerDigitalPost.Klient/KlientKonfigurasjon.cs
+++ b/Difi.SikkerDigitalPost.Klient/KlientKonfigurasjon.cs
@@ -84,7 +84,7 @@ namespace Difi.SikkerDigitalPost.Klient
         /// <summary>
         /// Setter om logging skal gjøres til fil for alle meldinger som går mellom Klientbibliotek og Meldingsformidler
         /// </summary>
-        public bool DebugLoggTilFil { get; set; }
+        public bool LoggXmlTilFil { get; set; }
 
         public string StandardLoggSti { get; set; }
 
@@ -100,7 +100,7 @@ namespace Difi.SikkerDigitalPost.Klient
             ProxyScheme = SetFromAppConfig<string>("SDP:ProxyScheme", "https");
             TimeoutIMillisekunder = SetFromAppConfig<int>("SDP:TimeoutIMillisekunder", (int)TimeSpan.FromSeconds(30).TotalMilliseconds);
             Logger = Logging.TraceLogger();
-            DebugLoggTilFil = SetFromAppConfig<bool>("SDP:DebugLoggTilFil", false);
+            LoggXmlTilFil = SetFromAppConfig<bool>("SDP:LoggXmlTilFil", false);
             StandardLoggSti = SetFromAppConfig<string>("SDP:LoggSti", Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Digipost"));
         }
 


### PR DESCRIPTION
Tidligere har vi hatt et felt på Klientkonfigurasjon som har satt logging til fil: DebugLoggTilFil. Dette feltet er endret til LoggXmlTilFil, da det er det som er realiteten. Lettere å forholde seg til og lettere å forstå, da det ikke blandes med det å bruke loggfunksjonen. Dokumentasjonen er også fikset for å reflektere dette.