### PR TITLE
Simplifies ToStringWithUtcOffset

### DIFF
--- a/Difi.SikkerDigitalPost.Klient/Extensions/DateTimeExtensions.cs
+++ b/Difi.SikkerDigitalPost.Klient/Extensions/DateTimeExtensions.cs
@@ -6,18 +6,7 @@ namespace Difi.SikkerDigitalPost.Klient.Extensions
     {
         public static string ToStringWithUtcOffset(this DateTime dateTime)
         {
-            const string fullFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
-
-            string date = dateTime.ToString(fullFormat);
-
-            TimeZoneInfo timeZone = TimeZoneInfo.Local;
-            TimeSpan offset = timeZone.GetUtcOffset(dateTime);
-
-            var format = @"hh':'mm";
-            var fortegn = offset.CompareTo(TimeSpan.Zero) >= 0 ? "'+'" : "'-'";
-            format = String.Format("{0}{1}", fortegn, format);
-            
-            return dateTime.ToString(String.Format("{0}{1}", date, offset.ToString(format)));
+            return dateTime.ToString("O");
         }
 
     }


### PR DESCRIPTION
Uses ToString with formatting "O" as this is ISO8601 with UTC offset, giving exactly the same format as before, but now fixing #141.