### PR TITLE
Antall bytes på forsendelse

### DIFF
--- a/Difi.SikkerDigitalPost.Klient.Domene/Entiteter/Kvitteringer/Transport/Transportkvittering.cs
+++ b/Difi.SikkerDigitalPost.Klient.Domene/Entiteter/Kvitteringer/Transport/Transportkvittering.cs
@@ -6,5 +6,7 @@
             : base(string.Empty)
         {
         }
+
+        public long BytesCount { get; set; }
     }
 }

--- a/Difi.SikkerDigitalPost.Klient.Tester/AsicE/AsicEArkivTester.cs
+++ b/Difi.SikkerDigitalPost.Klient.Tester/AsicE/AsicEArkivTester.cs
@@ -1,0 +1,37 @@
+﻿using Difi.SikkerDigitalPost.Klient.Tester.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Difi.SikkerDigitalPost.Klient.Tester.AsicE
+{
+    [TestClass()]
+    public class AsicEArkivTester
+    {
+        [TestClass]
+        public class ContentBytesCountMethod : AsicEArkivTester
+        {
+            [TestMethod]
+            public void ReturnsProperBytesCount()
+            {
+                //Arrange
+                var forsendelse = DomeneUtility.GetDigitalForsendelseVarselFlereDokumenterHøyereSikkerhet();
+                var asicEArkiv = DomeneUtility.GetAsicEArkiv(forsendelse);
+
+                var expectedBytesCount = 0L;
+                expectedBytesCount += asicEArkiv.Manifest.Bytes.Length;
+                expectedBytesCount += asicEArkiv.Signatur.Bytes.Length;
+                expectedBytesCount += asicEArkiv.Dokumentpakke.Hoveddokument.Bytes.Length;
+
+                foreach (var dokument in asicEArkiv.Dokumentpakke.Vedlegg)
+                {
+                    expectedBytesCount+= dokument.Bytes.Length;
+                }
+
+                //Act
+                var actualBytesCount = asicEArkiv.ContentBytesCount;
+
+                //Assert
+                Assert.AreEqual(expectedBytesCount, actualBytesCount);
+            }
+        }
+    }
+}

--- a/Difi.SikkerDigitalPost.Klient.Tester/Difi.SikkerDigitalPost.Klient.Tester.csproj
+++ b/Difi.SikkerDigitalPost.Klient.Tester/Difi.SikkerDigitalPost.Klient.Tester.csproj
@@ -76,6 +76,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="AsicE\AsicEArkivTester.cs" />
     <Compile Include="Enhetstester\EpostvarselTester.cs" />
     <Compile Include="Enhetstester\SmsVarselTester.cs" />
     <Compile Include="Enhetstester\FysiskPostInfoTester.cs" />

--- a/Difi.SikkerDigitalPost.Klient.Tester/SmokeTester.cs
+++ b/Difi.SikkerDigitalPost.Klient.Tester/SmokeTester.cs
@@ -101,7 +101,7 @@ namespace Difi.SikkerDigitalPost.Klient.Tester
             Kvittering kvittering = null;
             while (hentKvitteringPåNytt && (prøvdPåNytt++ <= hentKvitteringMaksAntallGanger))
             {
-                Thread.Sleep(500);
+                Thread.Sleep(2000);
                 var kvitteringsforespørsel = new Kvitteringsforespørsel(forsendelse.Prioritet, forsendelse.MpcId);
                 kvittering = await sdpKlient.HentKvitteringAsync(kvitteringsforespørsel);
 


### PR DESCRIPTION
Det er nå mulig å hente ut antall bytes på forsendelse i `Transportkvittering`. Testen er nærmest unik som selve implementert kode, men det gir oss en sikkerhet under eventuell refaktorering. Se detaljert beskrivelse på hver commit (`...`)