### PR TITLE
Legger til organisasjonsnummer i Url

### DIFF
--- a/Difi.SikkerDigitalPost.Klient.Domene/Entiteter/Aktører/Databehandler.cs
+++ b/Difi.SikkerDigitalPost.Klient.Domene/Entiteter/Aktører/Databehandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography.X509Certificates;
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
 using ApiClientShared;
 using ApiClientShared.Enums;
 
@@ -8,6 +9,14 @@ namespace Difi.SikkerDigitalPost.Klient.Domene.Entiteter.Aktører
     {
         /// <param name="organisasjonsnummer">Organisasjonsnummeret til avsender av brevet.</param>
         /// <param name="sertifikat">Avsenders Sertifikat: Virksomhetssertifikat.</param>
+        [Obsolete("Bruk konstruktør med klassen Organisasjonsnummer. Denne blir fjernet for å bedre typesikkerhet.")]
+        public Databehandler(string organisasjonsnummer, X509Certificate2 sertifikat)
+            : this(new Organisasjonsnummer(organisasjonsnummer), sertifikat)
+        {
+        }
+
+        /// <param name="organisasjonsnummer">Organisasjonsnummeret til avsender av brevet.</param>
+        /// <param name="sertifikat">Avsenders Sertifikat: Virksomhetssertifikat.</param>
         public Databehandler(Organisasjonsnummer organisasjonsnummer, X509Certificate2 sertifikat)
         {
             Organisasjonsnummer = organisasjonsnummer;
@@ -15,9 +24,13 @@ namespace Difi.SikkerDigitalPost.Klient.Domene.Entiteter.Aktører
         }
 
         /// <param name="organisasjonsnummer">Organisasjonsnummeret til avsender av brevet.</param>
-        /// <param name="sertifikat">Avsenders Sertifikat: Virksomhetssertifikat.</param>
-        public Databehandler(string organisasjonsnummer, X509Certificate2 sertifikat)
-            : this(new Organisasjonsnummer(organisasjonsnummer), sertifikat)
+        /// <param name="sertifikatThumbprint">
+        ///     Thumbprint til databehandlersertifikatet. Se guide på
+        ///     http://difi.github.io/sikker-digital-post-klient-dotnet/#databehandlersertifikat
+        /// </param>
+        [Obsolete("Bruk konstruktør med klassen Organisasjonsnummer. Denne blir fjernet for å bedre typesikkerhet.")]
+        public Databehandler(string organisasjonsnummer, string sertifikatThumbprint)
+            : this(new Organisasjonsnummer(organisasjonsnummer), sertifikatThumbprint)
         {
         }
 
@@ -26,9 +39,9 @@ namespace Difi.SikkerDigitalPost.Klient.Domene.Entiteter.Aktører
         ///     Thumbprint til databehandlersertifikatet. Se guide på
         ///     http://difi.github.io/sikker-digital-post-klient-dotnet/#databehandlersertifikat
         /// </param>
-        public Databehandler(string organisasjonsnummer, string sertifikatThumbprint)
+        public Databehandler(Organisasjonsnummer organisasjonsnummer, string sertifikatThumbprint)
         {
-            Organisasjonsnummer = new Organisasjonsnummer(organisasjonsnummer);
+            Organisasjonsnummer = organisasjonsnummer;
             Sertifikat = CertificateUtility.SenderCertificate(sertifikatThumbprint, Language.Norwegian);
         }
 

--- a/Difi.SikkerDigitalPost.Klient.Domene/Entiteter/Aktører/Databehandler.cs
+++ b/Difi.SikkerDigitalPost.Klient.Domene/Entiteter/Aktører/Databehandler.cs
@@ -9,7 +9,7 @@ namespace Difi.SikkerDigitalPost.Klient.Domene.Entiteter.Aktører
     {
         /// <param name="organisasjonsnummer">Organisasjonsnummeret til avsender av brevet.</param>
         /// <param name="sertifikat">Avsenders Sertifikat: Virksomhetssertifikat.</param>
-        [Obsolete("Bruk konstruktør med klassen Organisasjonsnummer. Denne blir fjernet for å bedre typesikkerhet.")]
+        [Obsolete("Bruk konstruktør Databehandler(Organisasjonsnummer, string). Denne blir fjernet for å bedre typesikkerhet.")]
         public Databehandler(string organisasjonsnummer, X509Certificate2 sertifikat)
             : this(new Organisasjonsnummer(organisasjonsnummer), sertifikat)
         {
@@ -28,7 +28,7 @@ namespace Difi.SikkerDigitalPost.Klient.Domene.Entiteter.Aktører
         ///     Thumbprint til databehandlersertifikatet. Se guide på
         ///     http://difi.github.io/sikker-digital-post-klient-dotnet/#databehandlersertifikat
         /// </param>
-        [Obsolete("Bruk konstruktør med klassen Organisasjonsnummer. Denne blir fjernet for å bedre typesikkerhet.")]
+        [Obsolete("Bruk konstruktør Databehandler(Organisasjonsnummer, string). Denne blir fjernet for å bedre typesikkerhet.")]
         public Databehandler(string organisasjonsnummer, string sertifikatThumbprint)
             : this(new Organisasjonsnummer(organisasjonsnummer), sertifikatThumbprint)
         {

--- a/Difi.SikkerDigitalPost.Klient.Domene/Entiteter/Organisasjonsnummer.cs
+++ b/Difi.SikkerDigitalPost.Klient.Domene/Entiteter/Organisasjonsnummer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 using Difi.SikkerDigitalPost.Klient.Domene.Exceptions;
 
 namespace Difi.SikkerDigitalPost.Klient.Domene.Entiteter
@@ -6,6 +7,7 @@ namespace Difi.SikkerDigitalPost.Klient.Domene.Entiteter
     public class Organisasjonsnummer
     {
         public static readonly string Iso6523Pattern = "^([0-9]{4}:)?([0-9]{9})$";
+        private const string CountryCodeOrganizationNumberNorway = "9908";
 
         /// <summary>
         ///     Stringrepresentasjon av organisasjonsnummeret
@@ -22,9 +24,15 @@ namespace Difi.SikkerDigitalPost.Klient.Domene.Entiteter
         ///     Organisasjonsnummer på ISO6523-format
         /// </summary>
         /// <returns>Organisasjonsnummer, prefikset med '9908':, som er id for 'Enhetsregistret ved Brønnøysundregisterne'</returns>
+        [Obsolete("Bruk OrganisasjonsnummerMedLandkode. Blir fjernet fordi navnet er obskurt og i beste fall litt feil.")]
         public string Iso6523()
         {
-            return Verdi.StartsWith("9908:") ? Verdi : $"9908:{Verdi}";
+            return OrganisasjonsnummerMedLandkode();
+        }
+
+        public string OrganisasjonsnummerMedLandkode()
+        {
+            return Verdi.StartsWith($"{CountryCodeOrganizationNumberNorway}:") ? Verdi : $"{CountryCodeOrganizationNumberNorway}:{Verdi}";
         }
 
         public static Organisasjonsnummer FraIso6523(string iso6523Orgnr)

--- a/Difi.SikkerDigitalPost.Klient.Domene/Entiteter/Organisasjonsnummer.cs
+++ b/Difi.SikkerDigitalPost.Klient.Domene/Entiteter/Organisasjonsnummer.cs
@@ -6,45 +6,45 @@ namespace Difi.SikkerDigitalPost.Klient.Domene.Entiteter
 {
     public class Organisasjonsnummer
     {
-        public static readonly string Iso6523Pattern = "^([0-9]{4}:)?([0-9]{9})$";
         private const string CountryCodeOrganizationNumberNorway = "9908";
+        public static readonly string OrganisasjonsnummerPattern = "^([0-9]{4}:)?([0-9]{9})$";
 
-        /// <summary>
-        ///     Stringrepresentasjon av organisasjonsnummeret
-        /// </summary>
-        public readonly string Verdi;
-
-        /// <param name="verdi">Stringrepresentasjon av organisasjonsnummeret</param>
-        public Organisasjonsnummer(string verdi)
+        public Organisasjonsnummer(string organisasjonsnummer)
         {
-            Verdi = verdi;
+            Verdi = GetValidatedOrganisasjonsNummerOrThrowException(organisasjonsnummer);
         }
+
+        public string Verdi { get; }
+
+        internal string WithCountryCode => Verdi.StartsWith($"{CountryCodeOrganizationNumberNorway}:") ? Verdi : $"{CountryCodeOrganizationNumberNorway}:{Verdi}";
 
         /// <summary>
         ///     Organisasjonsnummer på ISO6523-format
         /// </summary>
         /// <returns>Organisasjonsnummer, prefikset med '9908':, som er id for 'Enhetsregistret ved Brønnøysundregisterne'</returns>
-        [Obsolete("Bruk OrganisasjonsnummerMedLandkode. Blir fjernet fordi navnet er obskurt og i beste fall litt feil.")]
+        [Obsolete("Blir fjernet fordi navnet er obskurt og i beste fall litt feil, og skal ikke eksponeres ut av biblioteket.")]
         public string Iso6523()
         {
-            return OrganisasjonsnummerMedLandkode();
+            return WithCountryCode;
         }
 
-        public string OrganisasjonsnummerMedLandkode()
+        private static string GetValidatedOrganisasjonsNummerOrThrowException(string organisasjonsnummer)
         {
-            return Verdi.StartsWith($"{CountryCodeOrganizationNumberNorway}:") ? Verdi : $"{CountryCodeOrganizationNumberNorway}:{Verdi}";
-        }
-
-        public static Organisasjonsnummer FraIso6523(string iso6523Orgnr)
-        {
-            var match = Regex.Match(iso6523Orgnr, Iso6523Pattern);
+            var match = Regex.Match(organisasjonsnummer, OrganisasjonsnummerPattern);
 
             if (!match.Success)
             {
-                throw new KonfigurasjonsException("Ugyldig organisasjonsnummer. Forventet format er ISO 6523, " +
-                                                  $"fikk følgende organisasjonsnummer: {iso6523Orgnr}.");
+                throw new KonfigurasjonsException($"Ugyldig organisasjonsnummer. Fikk følgende organisasjonsnummer: {organisasjonsnummer}. " +
+                                                  "Organisasjonsnummeret skal være 9 siffer og kan prefikses med landkode 9908. Eksempler på dette er '9908:984661185' og '984661185'");
             }
-            return new Organisasjonsnummer(match.Groups[2].ToString());
+            const int organisasjonsnummerWithoutPrefixIndex = 2;
+            return match.Groups[organisasjonsnummerWithoutPrefixIndex].ToString();
+        }
+
+        [Obsolete("Vil bli fjernet fordi den ikke skal eksponeres ut til brukere av biblioteket.")]
+        public static Organisasjonsnummer FraIso6523(string iso6523Orgnr)
+        {
+            return new Organisasjonsnummer(GetValidatedOrganisasjonsNummerOrThrowException(iso6523Orgnr));
         }
     }
 }

--- a/Difi.SikkerDigitalPost.Klient.Tester/Difi.SikkerDigitalPost.Klient.Tester.csproj
+++ b/Difi.SikkerDigitalPost.Klient.Tester/Difi.SikkerDigitalPost.Klient.Tester.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Entiteter\Kvitteringer\Transport\TomKøKvitteringTests.cs" />
     <Compile Include="Entiteter\Kvitteringer\Transport\TransportFeiletKvitteringTests.cs" />
     <Compile Include="Entiteter\Kvitteringer\Transport\TransportOkKvitteringTests.cs" />
+    <Compile Include="Entiteter\OrganisasjonsnummerTests.cs" />
     <Compile Include="Entiteter\Post\ForsendelseTester.cs" />
     <Compile Include="Entiteter\Post\ForsendelseTests.cs" />
     <Compile Include="Extensions\EnumExtensionsTests.cs" />

--- a/Difi.SikkerDigitalPost.Klient.Tester/Difi.SikkerDigitalPost.Klient.Tester.csproj
+++ b/Difi.SikkerDigitalPost.Klient.Tester/Difi.SikkerDigitalPost.Klient.Tester.csproj
@@ -155,7 +155,7 @@
     <Compile Include="DokumentpakkeTests.cs" />
     <Compile Include="SertifikatTester.cs" />
     <Compile Include="XmlValidering\ResponseValidatorTests.cs" />
-    <Compile Include="XmlValidering\MiljøTester.cs" />
+    <Compile Include="XmlValidering\MiljøTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Difi.SikkerDigitalPost.Klient.Domene\Difi.SikkerDigitalPost.Klient.Domene.csproj">

--- a/Difi.SikkerDigitalPost.Klient.Tester/Entiteter/OrganisasjonsnummerTests.cs
+++ b/Difi.SikkerDigitalPost.Klient.Tester/Entiteter/OrganisasjonsnummerTests.cs
@@ -1,0 +1,56 @@
+﻿using Difi.SikkerDigitalPost.Klient.Domene.Entiteter;
+using Difi.SikkerDigitalPost.Klient.Domene.Exceptions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
+using Assert = Xunit.Assert;
+
+namespace Difi.SikkerDigitalPost.Klient.Tester.Entiteter
+{
+    public class OrganisasjonsnummerTests
+    {
+        public class ConstructorMethod
+        {
+            [Fact]
+            public void Initializes_verdi_properly()
+            {
+                //Arrange
+                const string orgnr = "123456789";
+
+                //Act
+                var organisasjonsnummer = new Organisasjonsnummer(orgnr);
+
+                //Assert
+                Assert.Equal(orgnr, organisasjonsnummer.Verdi);
+            }
+
+            [Fact]
+            public void Throws_exception_on_invalid()
+            {
+                //Arrange
+                const string orgnr = "1234567";
+
+                //Act
+                Assert.Throws<KonfigurasjonsException>(() => new Organisasjonsnummer(orgnr));
+            }
+        }
+
+        public class WithCountryCodeProperty
+        {
+            [Fact]
+            public void Returns_organisasjonsnummer_with_country_prefix()
+            {
+                //Arrange
+                const string source = "123456789";
+                const string expected = "9908:123456789";
+                var organisasjonsnummer = new Organisasjonsnummer(source);
+
+                //Act
+                var actual = organisasjonsnummer.WithCountryCode;
+
+                //Assert
+                Assert.Equal(expected, actual);
+
+            }
+        }
+    }
+}

--- a/Difi.SikkerDigitalPost.Klient.Tester/XmlValidering/MiljøTests.cs
+++ b/Difi.SikkerDigitalPost.Klient.Tester/XmlValidering/MiljøTests.cs
@@ -1,15 +1,38 @@
 ﻿using Difi.Felles.Utility.Utilities;
+using Difi.SikkerDigitalPost.Klient.Domene.Entiteter;
 using Difi.SikkerDigitalPost.Klient.XmlValidering;
 using Xunit;
 
 namespace Difi.SikkerDigitalPost.Klient.Tester.XmlValidering
 {
-    public class MiljøTester
+    public class MiljøTests
     {
-        public class GetMiljøMethod : MiljøTester
+        public class FullUriMethod : MiljøTests
         {
             [Fact]
-            public void ReturnererInitialisertFunksjoneltTestmiljø()
+            public void Appends_databehandler_and_avsender_organisasjonsnummer()
+            {
+                //Arrange
+                var miljø = Miljø.Produksjonsmiljø;
+
+                var databehandlerOrgnr = "123456789";
+                var avsenderOrgnr = "987654321";
+
+                var databehandlerOrganisasjonsnummer =  new Organisasjonsnummer(databehandlerOrgnr);
+                var avsenderOrganisasjonsnummer = new Organisasjonsnummer(avsenderOrgnr);
+
+                //Act
+                var fullUri = miljø.UrlWithOrganisasjonsnummer(databehandlerOrganisasjonsnummer, avsenderOrganisasjonsnummer);
+
+                //Assert
+                Assert.Contains($"9908:{databehandlerOrgnr}/9908:{avsenderOrgnr}", fullUri.ToString());
+            }
+        }
+
+        public class GetMiljøMethod : MiljøTests
+        {
+            [Fact]
+            public void Returnerer_initialisert_funksjonelt_testmiljø()
             {
                 //Arrange
                 var url = "https://qaoffentlig.meldingsformidler.digipost.no/api/ebms";
@@ -25,7 +48,7 @@ namespace Difi.SikkerDigitalPost.Klient.Tester.XmlValidering
             }
 
             [Fact]
-            public void ReturnererInitialisertProduksjonsmiljø()
+            public void Returnerer_initialisert_produksjonsmiljø()
             {
                 //Arrange
                 var url = "https://meldingsformidler.digipost.no/api/ebms";
@@ -41,7 +64,7 @@ namespace Difi.SikkerDigitalPost.Klient.Tester.XmlValidering
             }
 
             [Fact]
-            public void ReturnererInitialisertFunksjoneltTestmiljøNorskHelsenett()
+            public void Returnerer_initialisert_funksjonelt_testmiljø_norsk_helsenett()
             {
                 //Arrange
                 var url = "https://qaoffentlig.meldingsformidler.nhn.digipost.no:4445/api/";
@@ -57,7 +80,7 @@ namespace Difi.SikkerDigitalPost.Klient.Tester.XmlValidering
             }
 
             [Fact]
-            public void ReturnererInitialisertProduksjonsmiljøNorskHelsenett()
+            public void Returnerer_initialisert_produksjonsmiljø_norsk_helsenett()
             {
                 //Arrange
                 var url = "https://meldingsformidler.nhn.digipost.no:4444/api/";

--- a/Difi.SikkerDigitalPost.Klient/Envelope/Forretningsmelding/StandardBusinessDocumentHeader.cs
+++ b/Difi.SikkerDigitalPost.Klient/Envelope/Forretningsmelding/StandardBusinessDocumentHeader.cs
@@ -44,7 +44,7 @@ namespace Difi.SikkerDigitalPost.Klient.Envelope.Forretningsmelding
             {
                 var identifier = sender.AppendChildElement("Identifier", "ns3", NavneromUtility.StandardBusinessDocumentHeader, Context);
                 identifier.SetAttribute("Authority", "iso6523-actorid-upis");
-                identifier.InnerText = Settings.Databehandler.Organisasjonsnummer.Iso6523();
+                identifier.InnerText = Settings.Databehandler.Organisasjonsnummer.OrganisasjonsnummerMedLandkode();
             }
             return sender;
         }
@@ -55,7 +55,7 @@ namespace Difi.SikkerDigitalPost.Klient.Envelope.Forretningsmelding
             {
                 var identifier = receiver.AppendChildElement("Identifier", "ns3", NavneromUtility.StandardBusinessDocumentHeader, Context);
                 identifier.SetAttribute("Authority", "iso6523-actorid-upis");
-                identifier.InnerText = Settings.Forsendelse.PostInfo.Mottaker.OrganisasjonsnummerPostkasse.Iso6523();
+                identifier.InnerText = Settings.Forsendelse.PostInfo.Mottaker.OrganisasjonsnummerPostkasse.OrganisasjonsnummerMedLandkode();
             }
             return receiver;
         }

--- a/Difi.SikkerDigitalPost.Klient/Envelope/Forretningsmelding/StandardBusinessDocumentHeader.cs
+++ b/Difi.SikkerDigitalPost.Klient/Envelope/Forretningsmelding/StandardBusinessDocumentHeader.cs
@@ -44,7 +44,7 @@ namespace Difi.SikkerDigitalPost.Klient.Envelope.Forretningsmelding
             {
                 var identifier = sender.AppendChildElement("Identifier", "ns3", NavneromUtility.StandardBusinessDocumentHeader, Context);
                 identifier.SetAttribute("Authority", "iso6523-actorid-upis");
-                identifier.InnerText = Settings.Databehandler.Organisasjonsnummer.OrganisasjonsnummerMedLandkode();
+                identifier.InnerText = Settings.Databehandler.Organisasjonsnummer.WithCountryCode;
             }
             return sender;
         }
@@ -55,7 +55,7 @@ namespace Difi.SikkerDigitalPost.Klient.Envelope.Forretningsmelding
             {
                 var identifier = receiver.AppendChildElement("Identifier", "ns3", NavneromUtility.StandardBusinessDocumentHeader, Context);
                 identifier.SetAttribute("Authority", "iso6523-actorid-upis");
-                identifier.InnerText = Settings.Forsendelse.PostInfo.Mottaker.OrganisasjonsnummerPostkasse.OrganisasjonsnummerMedLandkode();
+                identifier.InnerText = Settings.Forsendelse.PostInfo.Mottaker.OrganisasjonsnummerPostkasse.WithCountryCode;
             }
             return receiver;
         }

--- a/Difi.SikkerDigitalPost.Klient/XmlValidering/Miljø.cs
+++ b/Difi.SikkerDigitalPost.Klient/XmlValidering/Miljø.cs
@@ -15,7 +15,7 @@ namespace Difi.SikkerDigitalPost.Klient.XmlValidering
 
         internal Uri UrlWithOrganisasjonsnummer(Organisasjonsnummer databehandler, Organisasjonsnummer avsender)
         {
-            return new Uri(Url,$"{databehandler.OrganisasjonsnummerMedLandkode()}/{avsender.OrganisasjonsnummerMedLandkode()}");
+            return new Uri(Url,$"{databehandler.WithCountryCode}/{avsender.WithCountryCode}");
         }
 
         public static Miljø FunksjoneltTestmiljø => new Miljø(

--- a/Difi.SikkerDigitalPost.Klient/XmlValidering/Miljø.cs
+++ b/Difi.SikkerDigitalPost.Klient/XmlValidering/Miljø.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Difi.Felles.Utility;
 using Difi.Felles.Utility.Utilities;
+using Difi.SikkerDigitalPost.Klient.Domene.Entiteter;
 
 namespace Difi.SikkerDigitalPost.Klient.XmlValidering
 {
@@ -10,6 +11,11 @@ namespace Difi.SikkerDigitalPost.Klient.XmlValidering
         {
             CertificateChainValidator = certificateChainValidator;
             Url = url;
+        }
+
+        internal Uri UrlWithOrganisasjonsnummer(Organisasjonsnummer databehandler, Organisasjonsnummer avsender)
+        {
+            return new Uri(Url,$"{databehandler.OrganisasjonsnummerMedLandkode()}/{avsender.OrganisasjonsnummerMedLandkode()}");
         }
 
         public static Miljø FunksjoneltTestmiljø => new Miljø(

--- a/SolutionItems/SharedAssemblyInfo.cs
+++ b/SolutionItems/SharedAssemblyInfo.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("1.9.0.*")]
+[assembly: AssemblyVersion("1.10.0.*")]
 
 #pragma warning disable CS7035 // The specified version string does not conform to the recommended format - major.minor.build.revision
-[assembly: AssemblyFileVersion("1.9.0.*")]
+[assembly: AssemblyFileVersion("1.10.0.*")]
 #pragma warning restore CS7035 // The specified version string does not conform to the recommended format - major.minor.build.revision


### PR DESCRIPTION
- Legger også til deprecated på `Databehandler`-konstruktører som tar inn string, og la til en ekstra som manglet for konstruktør med Thumbprint
- Deprecater `Iso6523`-metode som er kryptisk og erstatter den med `OrganisasjonsnummerMedLandkode`
- I RequestHelper bygger vi Url avhengig av om vi sender en Forsendelse eller ikke. Har vi en forsendelse så bygger vi med organisasjonsnummer, ellers er alt som før.
- Bumper minorversjon - dette påvirker ikke brukere direkte, for vi bruker `Obsolete`-flagg på metoder som skal erstattes
- Løser #114 