### PR TITLE
Fikser sertifikatbeskrivelse og litt småopprydding i docs

### DIFF
--- a/difi-sikker-digital-post-klient.nuspec
+++ b/difi-sikker-digital-post-klient.nuspec
@@ -4,8 +4,8 @@
         <id>difi-sikker-digital-post-klient</id>
         <version>$version$</version>
         <authors>Direktoratet for forvaltning og IKT (Difi)</authors>
-        <owners>PDirektoratet for forvaltning og IKT (Difi)</owners>
-        <projectUrl>https://github.com/difi/sikker-digital-post-net-klient/</projectUrl>
+        <owners>Direktoratet for forvaltning og IKT (Difi)</owners>
+        <projectUrl>https://github.com/difi/sikker-digital-post-klient-dotnet</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Klientbibliotek for sending av sikker digital post for offentlig sektor.</description>
         <copyright>Copyright 2016</copyright>

--- a/docs/_v1_6_11/1_hvordan-komme-i-gang.md
+++ b/docs/_v1_6_11/1_hvordan-komme-i-gang.md
@@ -11,6 +11,6 @@ Klienten er tilgjengelig som en NuGet-pakke. Denne vil oppdateres jevnlig etter 
 For å installere NuGet-pakken, gjør følgende:
 
 1. Velg _TOOLS -> NuGet Package Manager -> Manage Nuget Packages for Solution..._
-2. Søk etter _sikker-digital-post_.
+1. Søk etter _sikker-digital-post_.
 	* Ønsker du pre-release, må du sørge for at det står _Include Prerelease_ i drop-down menyen rett over søkeresuløtatene (der det står _Stable Only_).
-3. Velg _sikker-digital-post-klient_ og trykk _Install_.
+1. Velg _sikker-digital-post-klient_ og trykk _Install_.

--- a/docs/_v1_6_11/2_sende-post.md
+++ b/docs/_v1_6_11/2_sende-post.md
@@ -6,15 +6,13 @@ description: Hvordan sende fysisk og digital post
 isHome: false
 ---
 
-<blockquote>Det anbefales å bruke dokumentasjon i klassene for mer detaljert beskrivelse av inputparametere.</blockquote>
+> Det anbefales å bruke dokumentasjon i klassene for mer detaljert beskrivelse av inputparametere.
 
-<h3 id="postinfodigital">PostInfo for digital post</h3>
+### PostInfo for digital post
 
 Først, lag en motaker av type `DigitalPostMottaker`:
 
-<blockquote>
-Postkassetjenesteleverandørene har ulik behandling av ikke-sensitiv tittel. Se <a href="http://begrep.difi.no/Felles/ikkeSensitivTittel">begrep.difi.no</a> for detaljer om denne forskjellen.
-</blockquote>
+> Postkassetjenesteleverandørene har ulik behandling av ikke-sensitiv tittel. Se <a href="http://begrep.difi.no/Felles/ikkeSensitivTittel">begrep.difi.no</a> for detaljer om denne forskjellen. 
 
 {% highlight csharp %}
 
@@ -35,9 +33,9 @@ var postInfo = new DigitalPostInfo(mottaker, ikkeSensitivTittel, sikkerhetsnivå
 
 {% endhighlight%}
 
-<blockquote>Husk at<code>OrgnummerPostkasse</code> er organisasjonsnummer til leverandør av postkassetjenesten. Organisasjonsnummeret leveres fra oppslagstjenesten sammen med postkasseadressen og sertifikatet til innbygger.</blockquote>
+> Husk at<code>OrgnummerPostkasse</code> er organisasjonsnummer til leverandør av postkassetjenesten. Organisasjonsnummeret leveres fra oppslagstjenesten sammen med postkasseadressen og sertifikatet til innbygger.
 
-<h3 id="postinfofysisk">PostInfo for fysisk post</h3>
+### PostInfo for fysisk post
 
 Skal du sende fysisk post må du først lage en `FysiskPostMottaker`, en `FysiskPostReturMottaker` og sette informasjon om farge og makulering:
 
@@ -71,7 +69,7 @@ Her er adressen av type `NorskAdresse` eller `UtenlandskAdresse`.
 
 Ved sending av fysisk post må man oppgi en returadresse, uavhengig av om brevet er satt til `Posthåndtering.MakuleringMedMelding`. Oppretting av en FysiskPostInfo vil da se slik ut:
 
-<h3 id="oppsettfoersending">Oppsett før sending</h3>
+### Oppsett før sending
 
 Opprett en avsender og en databehandler:
 {% highlight csharp %}
@@ -91,7 +89,8 @@ Hvis man har flere avdelinger innenfor samme organisasjonsnummer, har disse fåt
 avsender.Avsenderidentifikator = "Avsenderidentifikator I Organisasjon";
 {% endhighlight %}
 
-<h3 id="oppretteforsendelse">Opprette forsendelse</h3>
+### Opprette forsendelse
+
 Deretterer kan du opprette forsendelse. Forsendelsen inneholder de dokumentene
  som skal til mottakeren:
 
@@ -123,7 +122,8 @@ var forsendelse = new Forsendelse(avsender, postInfo, dokumentpakke);
 
 {% endhighlight %}
 
-<h3 id="opprettKlient">Opprette klient og sende post </h3>
+### Opprette klient og sende post
+
 Siste steg er å opprette en `SikkerDigitalPostKlient`:
 
 {% highlight csharp %}
@@ -149,7 +149,8 @@ else if(transportkvittering is TransportFeiletKvittering)
 
 Transportkvitteringen får du tilbake umiddelbart; den trenger du ikke å polle for å få. 
 
-<h3 id="henteKvitteringer"> Hente kvitteringer</h3>
+### Hente kvitteringer
+
 For å hente kvitteringer må du sende en kvitteringsforespørsel:
 
 {% highlight csharp %}
@@ -199,9 +200,8 @@ if (kvittering is Feilmelding)
 
 {% endhighlight %}
 
-<blockquote>
-Husk at det ikke er mulig å hente nye kvitteringer før du har bekreftet mottak av nåværende. 
-</blockquote>
+> Husk at det ikke er mulig å hente nye kvitteringer før du har bekreftet mottak av nåværende. 
+
 
 {%highlight csharp%}
 sdpKlient.Bekreft((Forretningskvittering)kvittering);
@@ -209,6 +209,5 @@ sdpKlient.Bekreft((Forretningskvittering)kvittering);
 
 Kvitteringer du mottar når du gjør en kvitteringsforespørsel kan være av følgende typer: `Leveringskvittering`,`Åpningskvittering`, `Returpostkvittering`, `Mottakskvittering` eller `Feilmelding`. Kvittering kan også være av typen`TransportFeiletKvittering`. Dette kan skje når selve kvitteringsforespørselen er feilformatert.
 
-<blockquote>
-Husk at hvis du får <code>TomKøKvittering</code>, så er køen tom. Du henter bare kvitteringer fra kø gitt av <code>MpcId</code> og <code>Prioritet</code> på Dokumentpakken som ble sendt. Hvis ikke dette ble satt spesifikt vil <code>MpcId = ""</code> og <code>Prioritet = Prioritet.Normal</code>.
-</blockquote>
+> Husk at hvis du får `TomKøKvittering` så er køen tom. Du henter bare kvitteringer fra kø gitt av `MpcId` og `Prioritet`. Hvis ikke dette blir satt spesifikt vil det hentes fra kø hvor `MpcId = ""` og `Prioritet = Prioritet.Normal`.
+

--- a/docs/_v1_6_11/2_sende-post.md
+++ b/docs/_v1_6_11/2_sende-post.md
@@ -12,7 +12,7 @@ isHome: false
 
 Først, lag en motaker av type `DigitalPostMottaker`:
 
-> Postkassetjenesteleverandørene har ulik behandling av ikke-sensitiv tittel. Se <a href="http://begrep.difi.no/Felles/ikkeSensitivTittel">begrep.difi.no</a> for detaljer om denne forskjellen. 
+> Postkassetjenesteleverandørene har ulik behandling av ikke-sensitiv tittel. Se [begrep.difi.no](http://begrep.difi.no/Felles/ikkeSensitivTittel) for detaljer om denne forskjellen. 
 
 {% highlight csharp %}
 
@@ -33,7 +33,7 @@ var postInfo = new DigitalPostInfo(mottaker, ikkeSensitivTittel, sikkerhetsnivå
 
 {% endhighlight%}
 
-> Husk at<code>OrgnummerPostkasse</code> er organisasjonsnummer til leverandør av postkassetjenesten. Organisasjonsnummeret leveres fra oppslagstjenesten sammen med postkasseadressen og sertifikatet til innbygger.
+> Husk at `OrgnummerPostkasse` er organisasjonsnummer til leverandør av postkassetjenesten. Organisasjonsnummeret leveres fra oppslagstjenesten sammen med postkasseadressen og sertifikatet til innbygger.
 
 ### PostInfo for fysisk post
 

--- a/docs/_v1_6_11/3_logging.md
+++ b/docs/_v1_6_11/3_logging.md
@@ -6,12 +6,13 @@ description: Integrer SDP.NET mot din loggplattform
 isHome: false
 ---
 
-<h3 id="genereltOmlogging">Generelt</h3>
+### Generelt
+
 Klienten bruker _Common.Logging API_ for å abstrahere logging. Det er opp til brukeren å imlementere API med et passende loggrammeverk, men vi viser hvordan dette kan gjøres med Log4Net.
 
 Loggnivå `DEBUG` vil logge resultat for forespørsler som går bra og de  som feiler, `WARN` bare for feilede forespørsler eller verre, mens `ERROR`  bare skjer om sending av brev feilet. Disse loggerne vil være under `Difi.SikkerDigitalPost.Klient`
 
-<h3 id="log4net">Implementere Log4Net som logger</h3>
+### Implementere Log4Net som logger
 
 1. Installer Nuget-pakke `Common.Logging.Log4Net`. Denne vil da også installere avhengighetene `Common.Logging.Core` og `Common.Logging`. Merk at versjoneringen her er litt underlig, men et søk i Nuget Gallery vil f.eks. vise at Log4Net 2.0.3 har pakkenavn _Log4net [1.2.13] 2.0.3_. Da er det `Common.Logging.Log4Net1213` som skal installeres. 
 2. Legg merke til hvilken versjon av Log4net som faktisk installeres. Av en eller annen grunn kan det bli 2.0.0 som installeres. Da må versjonen oppdateres til 2.0.3.

--- a/docs/_v1_6_11/5_sertifikater.md
+++ b/docs/_v1_6_11/5_sertifikater.md
@@ -6,26 +6,32 @@ description: Installere sertifikater for signering og kryptering av post
 isHome: false
 ---
 
-For å sende sikker digital post trenger du å installere sertifikater. Grunnen til at vi ønsker å installere de er først og fremst sikkerhet. Alle sertifikater har en unik identifikator som kalles thumbprint. Hvis du ikke ønsker å håndtere selv i koden hvordan sertifikatene skal lastes, så kan du følge guiden under, steg for steg. Til slutt gjennomgås det hvordan du kan finne thumbprint til de installerte sertifikatene.
+Som bruker av dette biblioteket er du en Databehandler som har ansvar for sending av meldinger. For å gjøre dette trenger du et sertifikat for å kunne autentisere deg mot Meldingsformidleren. Du kan lese mer om aktørene [hos begrep.difi.no](http://begrep.difi.no/SikkerDigitalPost/forretningslag/Aktorer). Dette bør installeres på maskinen. Grunnen til at vi ønsker å installere det er først og fremst sikkerhet.
 
-<h3 id="databehandlersertifikat">Legg inn databehandlersertifikat i certificate store</h3>
+Alle sertifikater har en unik identifikator som kalles thumbprint. Hvis du ikke ønsker å håndtere selv i koden hvordan sertifikatene skal lastes, så kan du følge guiden under, steg for steg. Til slutt gjennomgås det hvordan du kan finne thumbprint til det installerte sertifikatet.
 
-<blockquote> Databehandlersertifikat er det sertifikatet du har fått utstedt for å kunne sende post.  </blockquote>
+### Legg inn databehandlersertifikat i certificate store
 
-1.  Dobbeltklikk på sertifikatet (Sertifikatnavn.p12)
-2.  Velg at sertifikatet skal lagres i _Current User_ og trykk _Next_
-3.  Filnavn skal nå være utfylt. Trykk _Next_
-4.  Skriv inn passord for privatekey og velg _Mark this key as exportable ..._, trykk _Next_
-5.  Velg _Automatically select the certificate store based on the type of certificate_
-6.  _Next_ og _Finish_
-7.  Får du spørsmål om å godta sertifikatet så gjør det.
-8.  Du skal da få en dialog som sier at importeringen var vellykket. Trykk _Ok_.
+> Databehandlersertifikat er det sertifikatet du har fått utstedt for å kunne sende post.
 
-<h3 id="finneinstallertsertifikat">Finne installert sertifikat</h3>
+1. Dobbeltklikk på sertifikatet (Sertifikatnavn.p12)
+1. Velg at sertifikatet skal lagres i _Current User_ eller _Local Machine og trykk _Next_
+1. Filnavn skal nå være utfylt. Trykk _Next_
+1. Skriv inn passord for privatekey og velg _Mark this key as exportable ..._, trykk _Next_
+1. Velg _Automatically select the certificate store based on the type of certificate_
+1. Klikk _Next_ og _Finish_
+1. Får du spørsmål om å godta sertifikatkjeden så du gjør det.
+1. Du skal da få en dialog som sier at importeringen var vellykket. Trykk _Ok_.
 
-For å finne databehandlersertifikat i kode så må du finne _thumbprint_. Dette gjøres lettest gjennom _Microsoft Management Console_ (mmc.exe).
+### Finne thumbprint til installert sertifikat
 
-<code>SikkerDigitalPostKlient</code> har støtte for å ta in _thumbprint_ direkte for <code>Databehandler</code> og <code>PostMottaker</code>.
-Ønsker du å sende inn sertifikater du har allerede har initialisert, kan du kalle konstruktøren som tar inn <code> X509Certificate2</code>.
+For å finne _thumbprint_ så er det lettest å gjøre det vha _Microsoft Management Console_ (mmc.exe).
 
-Som bruker av dette biblioteket er du en Databehandler som har ansvar for sending av meldinger. For å gjøre dette trenger du et sertifikat for å kunne autentisere deg mot Meldingsformidleren. Du kan lese mer om aktørene [her](http://begrep.difi.no/SikkerDigitalPost/forretningslag/Aktorer).
+1. Velg _File_ -> _Add/Remove Snap-in..._ 
+1. Merk _Certificates_ og trykk _Add >_
+1. Hvis sertifikatet ble installert i _Current User_ velges _My user account_, og hvis det er installert på _Local Machine_ så velges _Computer Account_. Klikk _Finish_ og så _OK_
+1. Ekspander _Certificates_-noden, velg _Personal_ og åpne _Certificates_
+1. Dobbeltklikk på sertifikatet du installerte
+1. Velg _Details_, scroll ned til _Thumbprint_ og kopier
+
+`SikkerDigitalPostKlient` har støtte for å ta in _thumbprint_ direkte for `Databehandler` og `PostMottaker`. Ønsker du å sende inn sertifikater du har allerede har initialisert, kan du kalle konstruktøren som tar inn `X509Certificate2`.

--- a/docs/_v1_6_11/5_sertifikater.md
+++ b/docs/_v1_6_11/5_sertifikater.md
@@ -6,7 +6,7 @@ description: Installere sertifikater for signering og kryptering av post
 isHome: false
 ---
 
-Som bruker av dette biblioteket er du en Databehandler som har ansvar for sending av meldinger. For å gjøre dette trenger du et sertifikat for å kunne autentisere deg mot Meldingsformidleren. Du kan lese mer om aktørene [hos begrep.difi.no](http://begrep.difi.no/SikkerDigitalPost/forretningslag/Aktorer). Dette bør installeres på maskinen. Grunnen til at vi ønsker å installere det er først og fremst sikkerhet.
+Som bruker av dette biblioteket er du en Databehandler som har ansvar for sending av meldinger. For å gjøre dette trenger du et sertifikat for å kunne autentisere deg mot Meldingsformidleren. Du kan lese mer om aktørene hos [begrep.difi.no](http://begrep.difi.no/SikkerDigitalPost/forretningslag/Aktorer). Dette bør installeres på maskinen som skal bruke klientbiblioteket. Grunnen til at vi ønsker å installere det er for å ikke ha passord i klartekst i koden.
 
 Alle sertifikater har en unik identifikator som kalles thumbprint. Hvis du ikke ønsker å håndtere selv i koden hvordan sertifikatene skal lastes, så kan du følge guiden under, steg for steg. Til slutt gjennomgås det hvordan du kan finne thumbprint til det installerte sertifikatet.
 
@@ -15,23 +15,23 @@ Alle sertifikater har en unik identifikator som kalles thumbprint. Hvis du ikke 
 > Databehandlersertifikat er det sertifikatet du har fått utstedt for å kunne sende post.
 
 1. Dobbeltklikk på sertifikatet (Sertifikatnavn.p12)
-1. Velg at sertifikatet skal lagres i _Current User_ eller _Local Machine og trykk _Next_
+1. Velg at sertifikatet skal lagres i _Current User_ eller _Local Machine_ og trykk _Next_
 1. Filnavn skal nå være utfylt. Trykk _Next_
-1. Skriv inn passord for privatekey og velg _Mark this key as exportable ..._, trykk _Next_
+1. Skriv inn passord for privatnøkkel og velg _Mark this key as exportable ..._, trykk _Next_
 1. Velg _Automatically select the certificate store based on the type of certificate_
 1. Klikk _Next_ og _Finish_
 1. Får du spørsmål om å godta sertifikatkjeden så du gjør det.
-1. Du skal da få en dialog som sier at importeringen var vellykket. Trykk _Ok_.
+1. Du skal da få en dialog som sier at importeringen var vellykket. Trykk _OK_.
 
 ### Finne thumbprint til installert sertifikat
 
-For å finne _thumbprint_ så er det lettest å gjøre det vha _Microsoft Management Console_ (mmc.exe).
+Det er enklest å finne thumbprint gjennom _Microsoft Management Console_ (mmc.exe).
 
 1. Velg _File_ -> _Add/Remove Snap-in..._ 
 1. Merk _Certificates_ og trykk _Add >_
-1. Hvis sertifikatet ble installert i _Current User_ velges _My user account_, og hvis det er installert på _Local Machine_ så velges _Computer Account_. Klikk _Finish_ og så _OK_
+1. Hvis sertifikatet ble installert i _Current User_ velges _My user account_, hvis det er installert på _Local Machine_ velges _Computer Account_. Klikk _Finish_ og _OK_
 1. Ekspander _Certificates_-noden, velg _Personal_ og åpne _Certificates_
 1. Dobbeltklikk på sertifikatet du installerte
 1. Velg _Details_, scroll ned til _Thumbprint_ og kopier
 
-`SikkerDigitalPostKlient` har støtte for å ta in _thumbprint_ direkte for `Databehandler` og `PostMottaker`. Ønsker du å sende inn sertifikater du har allerede har initialisert, kan du kalle konstruktøren som tar inn `X509Certificate2`.
+`SikkerDigitalPostKlient` har støtte for å ta inn _thumbprint_ direkte for `Databehandler` og `PostMottaker`. Ønsker du å sende inn sertifikater du har allerede har initialisert, kan du kalle konstruktøren som tar inn `X509Certificate2`.


### PR DESCRIPTION
- Var litt småfeil i beskrivelsen for sertifikatinstallering siden det bare er ett sertifikat som nå installeres. Legger også inn detaljert beskrivelse for installering av virksomhetssertifikat. Den manglet.
- Endrer h3-headere til å være ###. Blir lettere å lese og mindre vedlikehold siden id alltid blir rett.
- Oppdaterte url til repo i .nuspec siden den er endret.
- Nummererer kun med 1 i opplisting for lettere vedlikehold