### PR TITLE
Use api-client-shared v.4 for compatibility-reasons

### DIFF
--- a/Difi.SikkerDigitalPost.Klient.Domene/Difi.SikkerDigitalPost.Klient.Domene.csproj
+++ b/Difi.SikkerDigitalPost.Klient.Domene/Difi.SikkerDigitalPost.Klient.Domene.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
+<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
 
     <PropertyGroup>
         <Title>Difi Sikker Digital Post Klient Domene</Title>
@@ -45,7 +45,7 @@
     <ItemGroup>
       <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
       <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
-      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
+      <PackageReference Include="api-client-shared" Version="4.0.0" />
       <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />
     </ItemGroup>
 

--- a/Difi.SikkerDigitalPost.Klient.Resources/Difi.SikkerDigitalPost.Klient.Resources.csproj
+++ b/Difi.SikkerDigitalPost.Klient.Resources/Difi.SikkerDigitalPost.Klient.Resources.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
+<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
 
     <PropertyGroup>
         <Title>Difi Sikker Digital Post Klient Resources</Title>
@@ -59,7 +59,7 @@
     <ItemGroup>
       <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
       <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
-      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
+      <PackageReference Include="api-client-shared" Version="4.0.0" />
     </ItemGroup>
 
 </Project>

--- a/Difi.SikkerDigitalPost.Klient.Tester/Difi.SikkerDigitalPost.Klient.Tester.csproj
+++ b/Difi.SikkerDigitalPost.Klient.Tester/Difi.SikkerDigitalPost.Klient.Tester.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
+<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
 
     <PropertyGroup>
         <Title>Difi Sikker Digital Post Klient Tester</Title>
@@ -40,7 +40,7 @@
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
         <PackageReference Include="CompareNETObjects" Version="4.66.0" />
         <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
+        <PackageReference Include="api-client-shared" Version="4.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />
         <PackageReference Include="xunit.core" Version="2.4.1" />

--- a/Difi.SikkerDigitalPost.Klient/Difi.SikkerDigitalPost.Klient.csproj
+++ b/Difi.SikkerDigitalPost.Klient/Difi.SikkerDigitalPost.Klient.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
+<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
 
     <PropertyGroup>
         <Title>Difi Sikker Digital Post Klient</Title>
@@ -90,7 +90,7 @@
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
         <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
+        <PackageReference Include="api-client-shared" Version="4.0.0" />
         <PackageReference Include="log4net" Version="2.0.8" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />


### PR DESCRIPTION
The name of the `api-client-shared` dependency changed to `Digipost.Api.Client.Shared` when version 5 was released. This might cause som issues when using several libraries who depend on different versions of that dependency. Version 4 and version 7 _should be_ more or less interchangable as they are both written i .Net-standard.

This PR simply tries using v. 4 of `api-client-shared` to make version of this library that can operate smoothly with other libraries that depend on that version, e.g. `Digipost.Signature.Api.Client` and `difi-oppslagstjeneste-klient` 