### PR TITLE
Bump dependencies

### DIFF
--- a/Difi.SikkerDigitalPost.Klient.Domene/Difi.SikkerDigitalPost.Klient.Domene.csproj
+++ b/Difi.SikkerDigitalPost.Klient.Domene/Difi.SikkerDigitalPost.Klient.Domene.csproj
@@ -44,8 +44,8 @@
 
     <ItemGroup>
       <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-      <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
-      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
+      <PackageReference Include="Difi.Felles.Utility" Version="5.0.1" />
+      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
       <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />
     </ItemGroup>
 

--- a/Difi.SikkerDigitalPost.Klient.Resources/Difi.SikkerDigitalPost.Klient.Resources.csproj
+++ b/Difi.SikkerDigitalPost.Klient.Resources/Difi.SikkerDigitalPost.Klient.Resources.csproj
@@ -58,8 +58,8 @@
 
     <ItemGroup>
       <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-      <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
-      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
+      <PackageReference Include="Difi.Felles.Utility" Version="5.0.1" />
+      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
     </ItemGroup>
 
 </Project>

--- a/Difi.SikkerDigitalPost.Klient.Tester/Difi.SikkerDigitalPost.Klient.Tester.csproj
+++ b/Difi.SikkerDigitalPost.Klient.Tester/Difi.SikkerDigitalPost.Klient.Tester.csproj
@@ -38,13 +38,16 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="CompareNETObjects" Version="4.66.0" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="CompareNETObjects" Version="4.72.0" />
+        <PackageReference Include="Difi.Felles.Utility" Version="5.0.1" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />
         <PackageReference Include="xunit.core" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Difi.SikkerDigitalPost.Klient/Difi.SikkerDigitalPost.Klient.csproj
+++ b/Difi.SikkerDigitalPost.Klient/Difi.SikkerDigitalPost.Klient.csproj
@@ -89,8 +89,8 @@
     
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
+        <PackageReference Include="Difi.Felles.Utility" Version="5.0.1" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
         <PackageReference Include="log4net" Version="2.0.8" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />


### PR DESCRIPTION
Digipost.Api.Client.Shared 7.0.0 => 7.0.1
Difi.Felles.Utility 5.0.0 => 5.0.1
Bump of test dependencies.

Dette er et steg på vei for at https://github.com/difi/oppslagstjeneste-klient-dotnet , https://github.com/difi/felles-utility-dotnet og https://github.com/digipost/signature-api-client-dotnet/ skal avhenge av samme versjon av delte avhengigheter

https://github.com/digipost/signature-api-client-dotnet/pull/337
https://github.com/difi/felles-utility-dotnet/pull/26
